### PR TITLE
Update NZBimport.php: fix group shortnames

### DIFF
--- a/nzedb/NZBImport.php
+++ b/nzedb/NZBImport.php
@@ -300,15 +300,18 @@ class NZBImport
 				$group = (string)$group;
 
 				// If groups_id is -1 try to get a groups_id.
+				// why ask if $groupID === -1 when we did not change it since it was set it in line 281?
 				if ($groupID === -1) {
+					// check here if groupname is a valid name, sometimes nzbs contains shorted groupnames like: a.b.something
+					$groupN = Groups::isValidName($group);
+					if($groupN !== false) $group = $groupN;
+					
 					if (array_key_exists($group, $this->allGroups)) {
 						$groupID = $this->allGroups[$group];
-						if (!$groupName) {
-							$groupName = $group;
-						}
+						if (!$groupName) $groupName = $group;
 					} else {
-						$group = Groups::isValidName($group);
 						if ($group !== false) {
+							$group = $groupN;
 							/*$groupID = $this->groups->add([
 								'name' => $group,
 								'description' => 'Added by NZBimport script.',


### PR DESCRIPTION
sometimes nzbs contain shorted group names like: a.b.something and import script fails (script dies) without any error message because it tried to create the shortname group which often already exists as fullname and it dies right on "$groupID->save()"

steps to recall the bug:
create a NZB
add meta data group: a.b.something
add the group with fullname "alt.binaries.something" to nzedb
import the nzb from cli: "php NZBimport.php true true true 10"
import dies without an error or final message and no debugs shown.

Addresses issue #.

Changes made by this pull request.
-
-
-
